### PR TITLE
Qualify size_of in drain.rs

### DIFF
--- a/src/drain.rs
+++ b/src/drain.rs
@@ -140,7 +140,7 @@ unsafe impl<'a, V: VecLike> Sync for Drain<'a, V> where V::T: Sync {
 }
 impl<'a, V: VecLike> Drop for Drain<'a, V> {
     fn drop(&mut self) {
-        let is_zst = size_of::<V::T>() == 0;
+        let is_zst = mem::size_of::<V::T>() == 0;
 
         let iter = mem::take(&mut self.iter);
         let drop_len = iter.len();


### PR DESCRIPTION
"size_of" either needs to be imported or qualified. Chose to qualify to match convention in file.